### PR TITLE
ryu: Fix to install required libraries via pip

### DIFF
--- a/ryu/Dockerfile
+++ b/ryu/Dockerfile
@@ -6,12 +6,21 @@ FROM ubuntu:15.04
 
 MAINTAINER FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>
 
-RUN apt-get update
-RUN apt-get install -qy --no-install-recommends python-setuptools python-pip python-eventlet python-lxml python-msgpack unzip wget
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                        python-setuptools \
+                        python-pip \
+                        python-eventlet \
+                        python-lxml \
+                        python-msgpack \
+                        unzip \
+                        wget \
+                   && rm -rf /var/lib/apt/lists/*
 
 ENV HOME /root
 WORKDIR /root
 
 RUN wget --no-check-certificate https://github.com/osrg/ryu/archive/master.zip
-RUN unzip master.zip
-RUN cd ryu-master && python setup.py install
+RUN unzip master.zip && \
+    cd ryu-master && \
+    pip install -r tools/pip-requires && \
+    python setup.py install


### PR DESCRIPTION
Ryu uses pbr for packaging, but pbr does not support to install
requirements by setuptools.
So pbr team recommend that requirements be installed by using an
install tool such as pip.

This patch fixes to install requirements prior to running setup.py
install by pip.

In addition, this patch reformats codes by referring to 'Best
practices for writing Dockerfiles' on Docker Docs.

Signed-off-by: IWASE Yusuke iwase.yusuke0@gmail.com
