### PR TITLE
Ryu: Reduce the number of layers

### DIFF
--- a/ryu/Dockerfile
+++ b/ryu/Dockerfile
@@ -6,21 +6,19 @@ FROM ubuntu:15.04
 
 MAINTAINER FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-                        python-setuptools \
-                        python-pip \
-                        python-eventlet \
-                        python-lxml \
-                        python-msgpack \
-                        unzip \
-                        wget \
-                   && rm -rf /var/lib/apt/lists/*
-
 ENV HOME /root
 WORKDIR /root
 
-RUN wget --no-check-certificate https://github.com/osrg/ryu/archive/master.zip
-RUN unzip master.zip && \
-    cd ryu-master && \
-    pip install -r tools/pip-requires && \
-    python setup.py install
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    python-setuptools \
+    python-pip \
+    python-eventlet \
+    python-lxml \
+    python-msgpack \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -kL https://github.com/osrg/ryu/archive/master.tar.gz | tar -xvz \
+ && mv ryu-master ryu \
+ && cd ryu \
+ && pip install -r tools/pip-requires \
+ && python setup.py install

--- a/ryu/Dockerfile
+++ b/ryu/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 0.0.1
 
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 
 MAINTAINER FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>
 


### PR DESCRIPTION
According to "Best practices for writing Dockerfiles", we can minimize the number of layers
by using multi-line arguments.
This patch fixes to reduce the number of "RUN" instructions in order to avoid creating the
instructions layers.
Also, the following fixes to use the latest Ubuntu LTS.

Automated build result on DockerHub:
https://hub.docker.com/r/iwaseyusuke/ryu/builds/bs73wdnbphltcixt4i295aj/
