### PR TITLE
quagga/1.0: Fix Quagga version on 1.1.1

### DIFF
--- a/quagga/1.0/Dockerfile
+++ b/quagga/1.0/Dockerfile
@@ -2,12 +2,14 @@ FROM golang:1.7
 
 MAINTAINER ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
 
+ARG branch_name=quagga-1.1.1
+
 RUN useradd -M quagga
 RUN mkdir /var/log/quagga && chown quagga:quagga /var/log/quagga
 RUN mkdir /var/run/quagga && chown quagga:quagga /var/run/quagga
 RUN apt-get update && \
         apt-get install -qy git autoconf libtool gawk make telnet tcpdump libreadline-dev
-RUN git clone git://git.savannah.nongnu.org/quagga.git
+RUN git clone -b $branch_name --single-branch git://git.savannah.nongnu.org/quagga.git
 RUN cd quagga && ./bootstrap.sh && \
          ./configure --disable-doc --localstatedir=/var/run/quagga --enable-fpm && \
          make && make install


### PR DESCRIPTION
Currently, the version of Quagga in osrg/quagga:v1.0 is "1.0.20160315", but this version does not support the Next-Hop Tracking (NHT) features.
This patch fixes to use Quagga version 1.1.1 and enables the NHT features.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>