### PR TITLE
quagga/1.0: Use Debian 9 (stretch)

### DIFF
--- a/quagga/1.0/Dockerfile
+++ b/quagga/1.0/Dockerfile
@@ -1,16 +1,21 @@
-FROM golang:1.8-jessie
+FROM golang
 
 MAINTAINER ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
 
-ARG branch_name=quagga-1.1.1
+RUN apt-get update && apt-get install -qy --no-install-recommends \
+    supervisor \
+    quagga \
+    telnet \
+    tcpdump \
+ && rm -rf /var/lib/apt/lists/* \
+# Prepare state files directories
+ && mkdir /var/run/quagga && chown quagga:quagga /var/run/quagga \
+ && mkdir /var/log/quagga && chown quagga:quagga /var/log/quagga \
+# For the backward compatibility
+ && ln -s /usr/sbin/zebra /usr/local/sbin/zebra \
+ && ln -s /usr/sbin/ospfd /usr/local/sbin/ospfd \
+ && ln -s /usr/sbin/bgpd  /usr/local/sbin/bgpd
 
-RUN useradd -M quagga
-RUN mkdir /var/log/quagga && chown quagga:quagga /var/log/quagga
-RUN mkdir /var/run/quagga && chown quagga:quagga /var/run/quagga
-RUN apt-get update && \
-        apt-get install -qy git autoconf libtool gawk make telnet tcpdump libreadline-dev
-RUN git clone -b $branch_name --single-branch git://git.savannah.nongnu.org/quagga.git
-RUN cd quagga && ./bootstrap.sh && \
-         ./configure --disable-doc --localstatedir=/var/run/quagga --enable-fpm && \
-         make && make install
-RUN ldconfig
+ADD supervisord.conf /etc/supervisor/conf.d/quagga.conf
+
+ENTRYPOINT ["/usr/bin/supervisord"]

--- a/quagga/1.0/supervisord.conf
+++ b/quagga/1.0/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+
+[program:zebra]
+command=/usr/sbin/zebra
+[program:bgpd]
+command=/usr/sbin/bgpd


### PR DESCRIPTION
With Debian 9, we can install Quagga using Zebra API version 3 via apt packages.

Also, with this patch, this image will automatically start zebra and bgpd daemons by using supervisor whose behavior is the same as "osrg/quagga:latest".