### PR TITLE
Add Dockerfile for YABGP with version 0.4.0

### DIFF
--- a/yabgp/0.4.0/Dockerfile
+++ b/yabgp/0.4.0/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+
+ENV YABGP_VERSION 0.4.0
+
+ENV HOME /root
+WORKDIR /root
+
+RUN apt-get update && apt-get install -qy --no-install-recommends \
+# For calling REST API of YABGP
+    curl \
+# Utility
+    iproute2 \
+# Python
+    python-pip \
+    python-setuptools \
+# For building Python C extension
+    gcc \
+    python-dev \
+# Removes APT caches
+ && rm -rf /var/lib/apt/lists/* \
+# Installs YABGP via pip
+ && pip install yabgp==${YABGP_VERSION}


### PR DESCRIPTION
This PR adds Dockerfile for [YABGP](https://github.com/smartbgp/yabgp) which supposed to be used in [scenario_test of GoBGP](https://github.com/osrg/gobgp/tree/master/test/scenario_test).

Also, this image is supposed to be registered to [osrg's repo on Docker Hub](https://hub.docker.com/u/osrg/) as "osrg/yabgp:0.4.0" or so.